### PR TITLE
Bump version to 0.8.2

### DIFF
--- a/Casks/apigenie.rb
+++ b/Casks/apigenie.rb
@@ -1,9 +1,8 @@
 cask "apigenie" do
   version "0.8.2"
-  sha256 "e27b2208e7d0c5f0c41d44bfd882b92b67b75a17c2350016f9a5c529a7cca52c"
+  sha256 "6ec25b69afb0292cf1a11b6519b94b0f25c5d0c39f4bd353a1033ab690b24b47"
 
-  # url "https://apigenie.pl/dist/#{version}/apigenie-#{version}-macos_14-arm64.zip"
-  url "https://storage.googleapis.com/apigenie.pl/dist/#{version}/apigenie-#{version}-macos_15-arm64.zip",
+  url "https://storage.googleapis.com/apigenie.pl/dist/#{version}/apigenie-#{version}-macos15-arm64.zip",
       verified: "storage.googleapis.com/apigenie.pl/"
   name "apigenie"
   desc "Best software for OpenAPI development"
@@ -16,5 +15,5 @@ cask "apigenie" do
 
   depends_on macos: ">= :sonoma"
 
-  binary "apigenie-#{version}-macos_15-arm64", target: "apigenie"
+  binary "apigenie-#{version}-macos15-arm64", target: "apigenie"
 end


### PR DESCRIPTION
This PR bumps the Homebrew tap version to 0.8.2.