### PR TITLE
Bump version to 0.8.3

### DIFF
--- a/Casks/apigenie.rb
+++ b/Casks/apigenie.rb
@@ -1,6 +1,6 @@
 cask "apigenie" do
-  version "0.8.2"
-  sha256 "6ec25b69afb0292cf1a11b6519b94b0f25c5d0c39f4bd353a1033ab690b24b47"
+  version "0.8.3"
+  sha256 "4e6f9d88280799d871326f66337c619b2e405eb612193415e70ba9c2984492bf"
 
   url "https://storage.googleapis.com/apigenie.pl/dist/#{version}/apigenie-#{version}-macos15-arm64.zip",
       verified: "storage.googleapis.com/apigenie.pl/"


### PR DESCRIPTION
This PR bumps the Homebrew tap version to 0.8.3.