### PR TITLE
Bump version to 0.8.5

### DIFF
--- a/Casks/apigenie.rb
+++ b/Casks/apigenie.rb
@@ -1,5 +1,5 @@
 cask "apigenie" do
-  version "0.8.4"
+  version "0.8.5"
   sha256 "4e6f9d88280799d871326f66337c619b2e405eb612193415e70ba9c2984492bf"
 
   url "https://storage.googleapis.com/apigenie.pl/dist/#{version}/apigenie-#{version}-macos15-arm64.zip",


### PR DESCRIPTION
This PR bumps the Homebrew tap version to 0.8.5.