### PR TITLE
Bump version to 0.8.2

### DIFF
--- a/Casks/apigenie.rb
+++ b/Casks/apigenie.rb
@@ -1,6 +1,6 @@
 cask "apigenie" do
-  version "0.8.6"
-  sha256 "4e6f9d88280799d871326f66337c619b2e405eb612193415e70ba9c2984492bf"
+  version "0.8.2"
+  sha256 "bf5a4d59ce87617745b2967d96ddcd0534338824039e9bfd34fb99b3c8df0a15"
 
   url "https://storage.googleapis.com/apigenie.pl/dist/#{version}/apigenie-#{version}-macos15-arm64.zip",
       verified: "storage.googleapis.com/apigenie.pl/"


### PR DESCRIPTION
This PR bumps the Homebrew tap version to 0.8.2.